### PR TITLE
Fix ratio problem

### DIFF
--- a/notebooks/page_detection.ipynb
+++ b/notebooks/page_detection.ipynb
@@ -73,7 +73,7 @@
    "source": [
     "def edges_det(img, min_val, max_val):\n",
     "    \"\"\" Preprocessing (gray, thresh, filter, border) + Canny edge detection \"\"\"\n",
-    "    img = cv2.cvtColor(resize(img), cv2.COLOR_BGR2GRAY)\n",
+    "    img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)\n",
     "\n",
     "    # Applying blur and threshold\n",
     "    img = cv2.bilateralFilter(img, 9, 75, 75)\n",
@@ -129,8 +129,9 @@
     }
    ],
    "source": [
+    "small = resize(image)\n",
     "# Edge detection ()\n",
-    "edges_image = edges_det(image, 200, 250)\n",
+    "edges_image = edges_det(small, 200, 250)\n",
     "\n",
     "# Close gaps between edges (double page clouse => rectangle kernel)\n",
     "edges_image = cv2.morphologyEx(edges_image, cv2.MORPH_CLOSE, np.ones((5, 11)))\n",
@@ -224,14 +225,14 @@
     }
    ],
    "source": [
-    "page_contour = find_page_contours(edges_image, resize(image))\n",
+    "page_contour = find_page_contours(edges_image, small)\n",
     "print(\"PAGE CONTOUR:\")\n",
     "print(page_contour)\n",
-    "implt(cv2.drawContours(resize(image), [page_contour], -1, (0, 255, 0), 3))\n",
+    "implt(cv2.drawContours(small, [page_contour], -1, (0, 255, 0), 3))\n",
     "\n",
     "       \n",
     "# Recalculate to original scale\n",
-    "page_contour = page_contour.dot(ratio(image))"
+    "page_contour = page_contour.dot(ratio(image, small.shape[0]))"
    ]
   },
   {

--- a/src/ocr/page.py
+++ b/src/ocr/page.py
@@ -9,17 +9,18 @@ from .helpers import *
 
 def detection(image):
     """Finding Page."""
+    small = resize(image)
     # Edge detection
-    image_edges = _edges_detection(image, 200, 250)
+    image_edges = _edges_detection(small, 200, 250)
     
     # Close gaps between edges (double page clouse => rectangle kernel)
     closed_edges = cv2.morphologyEx(image_edges, 
                                     cv2.MORPH_CLOSE, 
                                     np.ones((5, 11)))
     # Countours
-    page_contour = _find_page_contours(closed_edges, resize(image))
+    page_contour = _find_page_contours(closed_edges, small)
     # Recalculate to original scale
-    page_contour = page_contour.dot(ratio(image))    
+    page_contour = page_contour.dot(ratio(image, small.shape[0]))
     # Transform prespective
     new_image = _persp_transform(image, page_contour)
     return new_image
@@ -27,7 +28,7 @@ def detection(image):
 
 def _edges_detection(img, minVal, maxVal):
     """Preprocessing (gray, thresh, filter, border) + Canny edge detection."""
-    img = cv2.cvtColor(resize(img), cv2.COLOR_BGR2GRAY)
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 
     img = cv2.bilateralFilter(img, 9, 75, 75)
     img = cv2.adaptiveThreshold(img, 255,


### PR DESCRIPTION
When `image.shape[0] < SMALL_HEIGHT`, the call to `ratio` must specify the `height` parameter, otherwise `page_contour` will be scaled down, rather than up.